### PR TITLE
docs: fixes to improve grep searching

### DIFF
--- a/docs/main.go
+++ b/docs/main.go
@@ -58,7 +58,8 @@ func (m *Docs) Prompt(ctx context.Context, prompt string) (string, error) {
 			You will be provided a prompt for information about the project
 			You have been provided the documentation in the files $llm and $llmsfull
 			You can read the contents of the files by selecting them and then using the contents tool. Always do this.
-			If the file is too big to understand at once, pass it to the $utils grep tool to search for what youre looking for
+			If the file is too big to understand at once, pass it to the $utils grep tool to search for what youre looking for.
+			When searching with the grep tool, use single keywords to search for context.
 			Using the files and tools available, answer the prompt as accurately and concicesly as possible, show code examples where applicable
 			Keep searching your input files and using your tools until you find the answer
 			Your prompt: $prompt`).

--- a/docs/utils/main.go
+++ b/docs/utils/main.go
@@ -9,7 +9,7 @@ import (
 
 type Utils struct{}
 
-// Returns surrounding lines of the file that match a pattern using grep
+// Returns surrounding lines of the file that match a pattern using grep. If a match is not found, returns an error
 func (m *Utils) Grep(
 	ctx context.Context,
 	// Dagger file to search in


### PR DESCRIPTION
When grep fails to find a match, it returns exit code 1

This updates the prompt and grep description so that LLMs can use the grep tool more reliably

Fixes https://github.com/kpenfound/agents/issues/10